### PR TITLE
Filter the metric name, allowing only alphanum, _, . and -

### DIFF
--- a/statstorage.cc
+++ b/statstorage.cc
@@ -10,6 +10,13 @@ using namespace std;
 
 StatStorage::StatStorage(const string& fname) : d_root(fname)
 {
+  if(regcomp(&d_preg, "^[A-Za-z0-9_.-]+$", REG_NOSUB|REG_EXTENDED))
+    throw runtime_error("Regular expression did not compile");
+}
+
+StatStorage::~StatStorage()
+{
+  regfree(&d_preg);
 }
 
 unsigned int StatStorage::getWeekNum(uint32_t t)
@@ -25,6 +32,9 @@ string StatStorage::makeFilename(const string& name, uint32_t timestamp)
 void StatStorage::store(const string& name, uint32_t timestamp, float value)
 {
   if(name.find("/") != string::npos)
+    return;
+
+  if (regexec(&d_preg, name.c_str(), 0, NULL, 0) == REG_NOMATCH)
     return;
 
   string fname=makeFilename(name, timestamp);

--- a/statstorage.hh
+++ b/statstorage.hh
@@ -4,12 +4,14 @@
 #include <limits>
 #include <tuple>
 #include <ctime>
+#include <regex.h>
 
 //! make your own instance, not thread safe
 class StatStorage
 {
 public:
   StatStorage(const std::string& root);
+  ~StatStorage();
   void store(const std::string& name, uint32_t timestamp, float value);
 
   struct Datum
@@ -31,6 +33,7 @@ public:
   std::vector<std::string> getMetrics();
 private:
   std::string d_root;
+  regex_t d_preg;
   struct Val { 
     uint32_t timestamp;
     float value;


### PR DESCRIPTION
Until now only '/' was forbidden. This was enough to prevent
directory traversal, but not XSS in the front page.