### PR TITLE
Wrap file descriptors and dynamically allocated memory to use RAII

### DIFF
--- a/interpolate.cc
+++ b/interpolate.cc
@@ -38,7 +38,7 @@ namespace {
     return ret;
   }
 
-
+#if 0
   void plotSolution(const vector<InterpolateDatum>& input, const VectorXd& res, int order)
   {
     ofstream plot("plot");
@@ -51,6 +51,7 @@ namespace {
     for(const auto& i : input) 
       r<<i.x<<'\t'<<i.y<<endl;
   }
+#endif
   
   vector<InterpolateDatum> normalize(const vector<InterpolateDatum>& input, double* x, double *factor)
   {

--- a/iputils.hh
+++ b/iputils.hh
@@ -406,5 +406,5 @@ inline int writen(int fd, const std::string& str)
 {
   return writen(fd, str.c_str(), str.size());
 }
-bool sockGetLine(int sock, string* ret);
+bool sockGetLine(int sock, string& ret, unsigned int timeout);
 #endif

--- a/mdump.cc
+++ b/mdump.cc
@@ -14,21 +14,22 @@ using std::endl;
 
 // syntax: mmanage
 int main(int argc, char** argv)
-try
 {
-  StatStorage ss("./stats");
-  auto metrics=ss.getMetrics();
-  cout<<"Have "<<metrics.size()<<" metrics"<<endl;
-  for(const auto& m: metrics) {
-    auto vals=ss.retrieve(m);
-    cout<<"Have "<<vals.size()<<" values for "<<m<<endl;
-    for(auto& v : vals)
-      cout<<v.timestamp<<"\t"<<v.value<<endl;
+  try
+  {
+    StatStorage ss("./stats");
+    auto metrics=ss.getMetrics();
+    cout<<"Have "<<metrics.size()<<" metrics"<<endl;
+    for(const auto& m: metrics) {
+      auto vals=ss.retrieve(m);
+      cout<<"Have "<<vals.size()<<" values for "<<m<<endl;
+      for(auto& v : vals)
+        cout<<v.timestamp<<"\t"<<v.value<<endl;
+    }
   }
-
-}
-catch(std::exception& e)
-{
-  cerr<<"Error: "<<e.what()<<endl;
-  exit(EXIT_FAILURE);
+  catch (const std::exception& e)
+  {
+    cerr<<"Error: "<<e.what()<<endl;
+    exit(EXIT_FAILURE);
+  }
 }

--- a/metromisc.hh
+++ b/metromisc.hh
@@ -4,6 +4,8 @@
 #include <errno.h>
 #include <string.h>
 #include <vector>
+#include <unistd.h>
+
 #include "dolog.hh"
 using std::string;
 
@@ -40,3 +42,27 @@ stringtok (Container &container, string const &in,
     i = j + 1;
   }
 }
+
+class Socket
+{
+public:
+  Socket(int descriptor): d_sock(descriptor)
+  {
+  }
+
+  ~Socket()
+  {
+    if (d_sock != -1) {
+      close(d_sock);
+      d_sock = -1;
+    }
+  }
+
+  int getHandle() const
+  {
+    return d_sock;
+  }
+
+private:
+  int d_sock{-1};
+};

--- a/metronome.cc
+++ b/metronome.cc
@@ -34,7 +34,7 @@ try
   string line;
 
   int numStored=0;
-  while(sockGetLine(sock, &line)) {
+  while(sockGetLine(sock, line, g_vm["carbon-timeout"].as<unsigned int>())) {
     // format: name value timestamp
 //    cout<<"Got: "<<line;
     vector<string> parts;
@@ -146,7 +146,7 @@ try
 
   for(int numrequests=0;;++numrequests) {
     string input, line;
-    while(sockGetLine(sock, &line)) {
+    while (sockGetLine(sock, line, g_vm["webserver-timeout"].as<unsigned int>())) {
 
       input.append(line);
       if(line.empty() || line=="\n" || line=="\r\n") // XXX NO
@@ -326,7 +326,9 @@ void processCommandLine(int argc, char **argv)
   desc.add_options()
     ("help,h", "produce help message")
     ("carbon-address", po::value<string>()->default_value("[::]:2003"), "Accept carbon data on this address")
+    ("carbon-timeout", po::value<unsigned int>()->default_value(5), "Maximum time in seconds to send a carbon line")
     ("webserver-address", po::value<string>()->default_value("[::]:8000"), "Provide HTTP service on this address")
+    ("webserver-timeout", po::value<unsigned int>()->default_value(5), "Maximum time in seconds to send an HTTP request line")
     ("http1.0", "If set, use http 1.0 semantics for lighttpd proxy")
     ("quiet", po::value<bool>()->default_value(true), "don't be too noisy")
     ("daemon", po::value<bool>()->default_value(true), "run in background")

--- a/mmanage.cc
+++ b/mmanage.cc
@@ -14,20 +14,21 @@ using std::endl;
 
 // syntax: mmanage
 int main(int argc, char** argv)
-try
 {
-  StatStorage ss("./stats");
-  auto metrics=ss.getMetrics();
-  cout<<"Have "<<metrics.size()<<" metrics"<<endl;
-  for(const auto& m: metrics) {
-    auto vals=ss.retrieve(m);
-    cout<<"Have "<<vals.size()<<" values for "<<m<<endl;
-    ss.store(m, vals);
+  try
+  {
+    StatStorage ss("./stats");
+    auto metrics=ss.getMetrics();
+    cout<<"Have "<<metrics.size()<<" metrics"<<endl;
+    for(const auto& m: metrics) {
+      auto vals=ss.retrieve(m);
+      cout<<"Have "<<vals.size()<<" values for "<<m<<endl;
+      ss.store(m, vals);
+    }
   }
-
-}
-catch(std::exception& e)
-{
-  cerr<<"Error: "<<e.what()<<endl;
-  exit(EXIT_FAILURE);
+  catch(const std::exception& e)
+  {
+    cerr<<"Error: "<<e.what()<<endl;
+    exit(EXIT_FAILURE);
+  }
 }

--- a/msubmit.cc
+++ b/msubmit.cc
@@ -12,54 +12,55 @@ using std::endl;
 
 // syntax: msubmit address
 int main(int argc, char** argv)
-try
 {
-  if(argc!=2) {
-    cerr<<"Syntax: (echo metric1 value1 ; echo metric2 value2 $(date +%s) ) |  msubmit carbon-server-address"<<endl;
+  try
+  {
+    if(argc!=2) {
+      cerr<<"Syntax: (echo metric1 value1 ; echo metric2 value2 $(date +%s) ) |  msubmit carbon-server-address"<<endl;
+      exit(EXIT_FAILURE);
+    }
+    ComboAddress remote(argv[1], 2003);
+    time_t now = time(nullptr);
+
+    int s = SSocket(remote.sin4.sin_family, SOCK_STREAM, 0);
+    SConnect(s, remote);
+    int ret;
+    std::string line;
+    while(getline(cin, line)) {
+      boost::trim_right(line);
+ 
+      std::vector<std::string> parts;
+      stringtok(parts, line, " \t\n");
+      if(parts.size() < 2)
+        throw std::runtime_error("Line '"+line+"' contained less than 2 parts");
+
+      string output = parts[0];
+      output+=' ';
+      output += parts[1];
+      output+=' ';
+      if(parts.size() > 2)
+        output += parts[2];
+      else
+        output += boost::lexical_cast<string>(now);
+      output += "\r\n";
+
+      ret = writen(s, output.c_str(), output.size()); //  format: name value timestamp
+      if(!ret)
+        throw std::runtime_error("Carbon server '"+remote.toStringWithPort()+"' closed socket while feeding data");
+      if(ret < 0)
+        throw std::runtime_error("Error writing to Carbon server '"+remote.toStringWithPort()+"': "+strerror(errno));
+    }
+    shutdown(s, SHUT_WR);
+    char c;
+    ret=read(s, &c, 1);
+    if(ret < 0)
+      throw std::runtime_error("Improper shutdown of Carbon session with '"+remote.toStringWithPort()+"': "+strerror(errno));
+    if(ret == 1)
+      throw std::runtime_error("Improper shutdown of Carbon session with '"+remote.toStringWithPort()+"': they sent us data");
+  }
+  catch(const std::exception& e)
+  {
+    cerr<<"Error: "<<e.what()<<endl;
     exit(EXIT_FAILURE);
   }
-  ComboAddress remote(argv[1], 2003);
-  time_t now = time(0);
-
-  int s = SSocket(remote.sin4.sin_family, SOCK_STREAM, 0);
-  SConnect(s, remote);
-  int ret;
-  std::string line;
-  while(getline(cin, line)) {
-    boost::trim_right(line);
- 
-    std::vector<std::string> parts;
-    stringtok(parts, line, " \t\n");
-    if(parts.size() < 2) 
-      throw std::runtime_error("Line '"+line+"' contained less than 2 parts");
-
-    string output = parts[0];
-    output+=' ';
-    output += parts[1];
-    output+=' ';
-    if(parts.size() > 2)
-      output += parts[2];
-    else
-      output += boost::lexical_cast<string>(now);
-    output += "\r\n";
-
-    ret = writen(s, output.c_str(), output.size()); //  format: name value timestamp
-    if(!ret)
-      throw std::runtime_error("Carbon server '"+remote.toStringWithPort()+"' closed socket while feeding data");
-    if(ret < 0)
-      throw std::runtime_error("Error writing to Carbon server '"+remote.toStringWithPort()+"': "+strerror(errno));
-  }
-  shutdown(s, SHUT_WR);
-  char c;
-  ret=read(s, &c, 1);
-  if(ret < 0)
-    throw std::runtime_error("Improper shutdown of Carbon session with '"+remote.toStringWithPort()+"': "+strerror(errno));
-  if(ret == 1)
-    throw std::runtime_error("Improper shutdown of Carbon session with '"+remote.toStringWithPort()+"': they sent us data");
-    
-}
-catch(std::exception& e)
-{
-  cerr<<"Error: "<<e.what()<<endl;
-  exit(EXIT_FAILURE);
 }


### PR DESCRIPTION
This PR wraps file descriptors (sockets, file and directory descriptors) and dynamically allocated memory in objects and smart pointers to prevent any leak. I did not see any, to be clear, but I believe this might prevent mistakes at a later time.

This PR is based on top of #75 to prevent a conflict later, but I can rebase it if needed.