### PR TITLE
Builder support for Debian Bullseye

### DIFF
--- a/builder-support/debian/control
+++ b/builder-support/debian/control
@@ -4,7 +4,7 @@ Priority: extra
 Standards-Version: 3.9.6
 Maintainer: PowerDNS Autobuilder <powerdns.support@powerdns.com>
 Origin: PowerDNS
-Build-Depends: debhelper (>= 9~), dh-autoreconf, dh-systemd, libtool, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-program-options-dev, autotools-dev, automake, autoconf, pkg-config, libeigen3-dev, libsystemd-dev
+Build-Depends: debhelper (>= 9~), dh-autoreconf, libtool, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-program-options-dev, autotools-dev, automake, autoconf, pkg-config, libeigen3-dev, libsystemd-dev
 Homepage: https://www.github.com/ahupowerdns/metronome
 
 Package: metronome

--- a/builder-support/dockerfiles/Dockerfile.target.debian-bullseye
+++ b/builder-support/dockerfiles/Dockerfile.target.debian-bullseye
@@ -1,0 +1,4 @@
+# First do the source builds
+@INCLUDE Dockerfile.target.sdist
+FROM debian:bullseye as dist-base
+@INCLUDE Dockerfile.debbuild


### PR DESCRIPTION
Adds `builder` support for Debian Bullseye.