### PR TITLE
Metronome bullseye

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
  - cd -
  - ./builder/build.sh centos-7
  - ./builder/build.sh debian-buster
+ - ./builder/build.sh debian-bullseye
 notifications:
   email:
     - bert.hubert@netherlabs.nl

--- a/builder-support/debian/control
+++ b/builder-support/debian/control
@@ -4,7 +4,7 @@ Priority: extra
 Standards-Version: 3.9.6
 Maintainer: PowerDNS Autobuilder <powerdns.support@powerdns.com>
 Origin: PowerDNS
-Build-Depends: debhelper (>= 9~), dh-autoreconf, dh-systemd, libtool, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-program-options-dev, autotools-dev, automake, autoconf, pkg-config, libeigen3-dev, libsystemd-dev
+Build-Depends: debhelper (>= 9.20160709) | dh-systemd, dh-autoreconf, libtool, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-program-options-dev, autotools-dev, automake, autoconf, pkg-config, libeigen3-dev, libsystemd-dev
 Homepage: https://www.github.com/ahupowerdns/metronome
 
 Package: metronome

--- a/builder-support/dockerfiles/Dockerfile.target.debian-bullseye
+++ b/builder-support/dockerfiles/Dockerfile.target.debian-bullseye
@@ -1,0 +1,4 @@
+# First do the source builds
+@INCLUDE Dockerfile.target.sdist
+FROM debian:bullseye as dist-base
+@INCLUDE Dockerfile.debbuild

--- a/html/graphs.js
+++ b/html/graphs.js
@@ -276,6 +276,12 @@ $(document).ready(function() {
             { name: servername+".latency", legend: "Latency (usec)", kind: "gauge"}
             ]};
 
+        var config7e = { items: [
+            { name: servername+".send-latency", legend: "Latency send (usec)", kind: "gauge"},
+            { name: servername+".cache-latency", legend: "Latency cache (usec)", kind: "gauge"},
+            { name: servername+".backend-latency", legend: "Latency backend (usec)", kind: "gauge"},
+            { name: servername+".receive-latency", legend: "Latency receive (usec)", kind: "gauge"}
+            ]};
 
 	var config8 = { items: [ 
             { 
@@ -284,12 +290,19 @@ $(document).ready(function() {
 		formula: m.percentalizer
 	    }]};    
 
-	var config9 = { items: [ 
-            { 
-		metrics: [servername+".query-cache-hit",servername+".query-cache-miss"], 
-		legend: "% query cache hitrate", 
-		formula: m.percentalizer
- 	    }]};    
+        var config8a = { items: [
+            {
+                metrics: [servername+".zone-cache-miss",servername+".zone-cache-hit"],
+                legend: "% zone cache missrate",
+                formula: m.percentalizer
+            }]};
+
+        var config9 = { items: [
+            {
+                metrics: [servername+".query-cache-miss",servername+".query-cache-hit"],
+                legend: "% query cache missrate",
+                formula: m.percentalizer
+            }]};
 
 	var config10 = { items: [ 
 		{name: servername+".query-cache-miss", legend: "Database queries/s"}
@@ -378,7 +391,7 @@ $(document).ready(function() {
                 
 	}
 	else if(components[2]=="auth") {
-	    configs=[config3, config6a, config6aa, config6b, config7, config7a, config7aa, config7ab, config7b, config7c, config7d, config8, config9, config10, config10a, config11, config12, config13, config14];
+	    configs=[config3, config6a, config6aa, config6b, config7, config7a, config7aa, config7ab, config7b, config7c, config7d, config7e, config8, config8a, config9, config10, config10a, config11, config12, config13, config14];
 	}
 	else if(components[0]=="dnsdist") {
 	    configs=[ { 


### PR DESCRIPTION
- Add Debian Bullseye build target
- Add auth zone-cache metrics
- Switch from hit- to miss-rate for the auth query cache (hit-rates are usually much higher than 50% so this will improve the resolution of the graph) 
- Add auth internal latency metrics

